### PR TITLE
Add support for configurable swagger paths

### DIFF
--- a/src/Clave.SwaggerCompare/EndpointService.cs
+++ b/src/Clave.SwaggerCompare/EndpointService.cs
@@ -12,9 +12,9 @@ namespace Clave.SwaggerCompare
 {
     internal static class EndpointService
     {
-        public static async Task<List<SwaggerUrlWithData>> GetAllEndpoints(HttpClient client, TestRun testRun)
+        public static async Task<List<SwaggerUrlWithData>> GetAllEndpoints(HttpClient client, TestRun testRun, string[] possibleSwaggerUrls)
         {
-            var swaggerDocObject = await SwaggerClient.ReadSwagger(client, testRun);
+            var swaggerDocObject = await SwaggerClient.ReadSwagger(client, testRun, possibleSwaggerUrls);
             if (swaggerDocObject == null)
             {
                 return null;

--- a/src/Clave.SwaggerCompare/LocalConfig.cs
+++ b/src/Clave.SwaggerCompare/LocalConfig.cs
@@ -5,6 +5,7 @@ namespace Clave.SwaggerCompare
 {
     public class LocalConfig
     {
+        public string[] PossibleSwaggerUrls;
         public ClientConfig Client1 { get; set; }
         public ClientConfig Client2 { get; set; }
         public IReadOnlyCollection<TestRun> TestRuns { get; set; }

--- a/src/Clave.SwaggerCompare/Program.cs
+++ b/src/Clave.SwaggerCompare/Program.cs
@@ -28,6 +28,8 @@ namespace Clave.SwaggerCompare
             LogInfo($"Client1: {config.Client1.Url}");
             LogInfo($"Client2: {config.Client2.Url}");
             LogInfo($"Response differences will be logged to {FileService.TestResultFolder()}");
+            
+            var possibleSwaggerUrls = config.PossibleSwaggerUrls;
 
             var client1 = new HttpClient
             {
@@ -48,7 +50,7 @@ namespace Clave.SwaggerCompare
             var testRunNumber = 1;
             foreach (var testRun in config.TestRuns)
             {
-                var swaggerUrls = await EndpointService.GetAllEndpoints(client1, testRun);
+                var swaggerUrls = await EndpointService.GetAllEndpoints(client1, testRun, possibleSwaggerUrls);
 
                 LogInfo($"{Environment.NewLine}Starting test run #{testRunNumber++} with {swaggerUrls.Count} matching API {"call".Pluralize(swaggerUrls.Count)} planned.");
                 foreach (var path in swaggerUrls)

--- a/src/Clave.SwaggerCompare/SwaggerClient.cs
+++ b/src/Clave.SwaggerCompare/SwaggerClient.cs
@@ -12,19 +12,20 @@ namespace Clave.SwaggerCompare
     {
         static SwaggerDocObject _swaggerResponse;
 
-        static readonly string[] PossibleSwaggerUrls =
+        public static readonly string[] PossibleSwaggerUrls =
             {"swagger/v1/swagger.json", "api/swagger/v1/swagger.json", "api/swagger/docs/v1", "swagger/docs/v1"};
 
-        public static async Task<SwaggerDocObject> ReadSwagger(HttpClient client, TestRun testRun)
+        public static async Task<SwaggerDocObject> ReadSwagger(HttpClient client, TestRun testRun, string[] possibleSwaggerUrls)
         {
-            return await Get(client);
+            return await Get(client, possibleSwaggerUrls);
         }
 
-        static async Task<SwaggerDocObject> Get(HttpClient client)
+        static async Task<SwaggerDocObject> Get(HttpClient client, string[] possibleSwaggerUrls)
         {
             if (_swaggerResponse != null) return _swaggerResponse;
+            var swaggerUrls = possibleSwaggerUrls?.Length > 0 ? possibleSwaggerUrls : PossibleSwaggerUrls;
 
-            foreach (var possibleSwaggerUrl in PossibleSwaggerUrls)
+            foreach (var possibleSwaggerUrl in swaggerUrls)
             {
                 try
                 {
@@ -42,7 +43,7 @@ namespace Clave.SwaggerCompare
                 }
             }
 
-            LogError($"Could not find any valid swagger JSON document at {client.BaseAddress} | {string.Join(", ", PossibleSwaggerUrls)}");
+            LogError($"Could not find any valid swagger JSON document at {client.BaseAddress} | {string.Join(", ", swaggerUrls)}");
             return null;
         }
     }


### PR DESCRIPTION
Some apis might use other swagger paths than the built in ones. Added support for specifying this, example config like so:

```jsonc
{
  "PossibleSwaggerUrls": ["swagger/json"], //provide a list of paths to look up here
  "Client1": {
    "Url": "http://localhost:8081/api/",
    "Headers": {}
  },
  "Client2": {
    "Url": "http://localhost:7071/api/",
    "Headers": {}
  },
  "TestRuns": [
    {
      "ExcludeEndpoints": [],
      "TreatParametersAsRequired": [],
      "UrlParameterTestValues": {
        "param1": "value1"
      },
      "IncludeEndpoints": []
    }
  ]
}
```